### PR TITLE
Add contact fields to user registration and profile

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,9 @@ class User extends Authenticatable
     protected $fillable = [
         'name',
         'email',
+        'country',
+        'phone',
+        'company',
         'password',
     ];
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -26,6 +26,9 @@ class UserFactory extends Factory
         return [
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
+            'country' => fake()->country(),
+            'phone' => fake()->e164PhoneNumber(),
+            'company' => fake()->company(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_10_01_060000_add_contact_fields_to_users_table.php
+++ b/database/migrations/2025_10_01_060000_add_contact_fields_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('country')->nullable()->after('email');
+            $table->string('phone')->nullable()->after('country');
+            $table->string('company')->nullable()->after('phone');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['country', 'phone', 'company']);
+        });
+    }
+};

--- a/database/seeders/AdminSeeder.php
+++ b/database/seeders/AdminSeeder.php
@@ -15,10 +15,13 @@ class AdminSeeder extends Seeder
     public function run(): void
   {
         $admin = User::firstOrCreate(
-            ['email' => 'admin@ticket.com'], 
+            ['email' => 'admin@ticket.com'],
             [
                 'name' => 'Super Admin',
-                'password' => Hash::make('00000000'), 
+                'country' => 'United States',
+                'phone' => '+1 555-0000',
+                'company' => 'Ticket HQ',
+                'password' => Hash::make('00000000'),
             ]
         );
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -18,6 +18,9 @@ class DatabaseSeeder extends Seeder
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',
+            'country' => 'United States',
+            'phone' => '+1 555-0100',
+            'company' => 'Example Co.',
         ]);
     }
 }

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -1,6 +1,6 @@
 <x-app-layout>
     <x-slot name="header">
-        <h2 class="font-bold text-2xl text-grey-600 tracking-wide">
+        <h2 class="font-bold text-2xl text-gray-600 tracking-wide">
             🎫 Customer Dashboard
         </h2>
     </x-slot>

--- a/resources/views/livewire/pages/auth/register.blade.php
+++ b/resources/views/livewire/pages/auth/register.blade.php
@@ -12,6 +12,9 @@ new #[Layout('layouts.guest')] class extends Component
 {
     public string $name = '';
     public string $email = '';
+    public string $country = '';
+    public string $phone = '';
+    public string $company = '';
     public string $password = '';
     public string $password_confirmation = '';
 
@@ -23,6 +26,9 @@ new #[Layout('layouts.guest')] class extends Component
     $validated = $this->validate([
         'name' => ['required', 'string', 'max:255'],
         'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+        'country' => ['nullable', 'string', 'max:255'],
+        'phone' => ['nullable', 'string', 'max:20'],
+        'company' => ['nullable', 'string', 'max:255'],
         'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
     ]);
 
@@ -69,6 +75,30 @@ new #[Layout('layouts.guest')] class extends Component
                     <label for="email" class="block text-sm font-medium text-gray-700 mb-1">Email Address</label>
                     <input wire:model="email" id="email" type="email" required
                         placeholder="your@email.com"
+                        class="w-full rounded-xl border-gray-300 focus:border-indigo-500 focus:ring focus:ring-indigo-200 text-gray-800 placeholder-gray-400 transition-all duration-300 px-4 py-2.5 group-hover:shadow-md">
+                </div>
+
+                <!-- Country -->
+                <div class="group">
+                    <label for="country" class="block text-sm font-medium text-gray-700 mb-1">Country</label>
+                    <input wire:model="country" id="country" type="text"
+                        placeholder="Where are you located?"
+                        class="w-full rounded-xl border-gray-300 focus:border-indigo-500 focus:ring focus:ring-indigo-200 text-gray-800 placeholder-gray-400 transition-all duration-300 px-4 py-2.5 group-hover:shadow-md">
+                </div>
+
+                <!-- Phone -->
+                <div class="group">
+                    <label for="phone" class="block text-sm font-medium text-gray-700 mb-1">Phone Number</label>
+                    <input wire:model="phone" id="phone" type="tel"
+                        placeholder="e.g. +1 555 123 4567"
+                        class="w-full rounded-xl border-gray-300 focus:border-indigo-500 focus:ring focus:ring-indigo-200 text-gray-800 placeholder-gray-400 transition-all duration-300 px-4 py-2.5 group-hover:shadow-md">
+                </div>
+
+                <!-- Company -->
+                <div class="group">
+                    <label for="company" class="block text-sm font-medium text-gray-700 mb-1">Company</label>
+                    <input wire:model="company" id="company" type="text"
+                        placeholder="Your organization"
                         class="w-full rounded-xl border-gray-300 focus:border-indigo-500 focus:ring focus:ring-indigo-200 text-gray-800 placeholder-gray-400 transition-all duration-300 px-4 py-2.5 group-hover:shadow-md">
                 </div>
 

--- a/resources/views/livewire/profile/update-profile-information-form.blade.php
+++ b/resources/views/livewire/profile/update-profile-information-form.blade.php
@@ -10,6 +10,9 @@ new class extends Component
 {
     public string $name = '';
     public string $email = '';
+    public ?string $country = '';
+    public ?string $phone = '';
+    public ?string $company = '';
 
     /**
      * Mount the component.
@@ -18,6 +21,9 @@ new class extends Component
     {
         $this->name = Auth::user()->name;
         $this->email = Auth::user()->email;
+        $this->country = Auth::user()->country;
+        $this->phone = Auth::user()->phone;
+        $this->company = Auth::user()->company;
     }
 
     /**
@@ -30,6 +36,9 @@ new class extends Component
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', Rule::unique(User::class)->ignore($user->id)],
+            'country' => ['nullable', 'string', 'max:255'],
+            'phone' => ['nullable', 'string', 'max:20'],
+            'company' => ['nullable', 'string', 'max:255'],
         ]);
 
         $user->fill($validated);
@@ -102,6 +111,24 @@ new class extends Component
                     @endif
                 </div>
             @endif
+        </div>
+
+        <div>
+            <x-input-label for="country" :value="__('Country')" />
+            <x-text-input wire:model="country" id="country" name="country" type="text" class="mt-1 block w-full" autocomplete="country" />
+            <x-input-error class="mt-2" :messages="$errors->get('country')" />
+        </div>
+
+        <div>
+            <x-input-label for="phone" :value="__('Phone')" />
+            <x-text-input wire:model="phone" id="phone" name="phone" type="tel" class="mt-1 block w-full" autocomplete="tel" />
+            <x-input-error class="mt-2" :messages="$errors->get('phone')" />
+        </div>
+
+        <div>
+            <x-input-label for="company" :value="__('Company')" />
+            <x-text-input wire:model="company" id="company" name="company" type="text" class="mt-1 block w-full" autocomplete="organization" />
+            <x-input-error class="mt-2" :messages="$errors->get('company')" />
         </div>
 
         <div class="flex items-center gap-4">

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -24,6 +24,9 @@ class RegistrationTest extends TestCase
         $component = Volt::test('pages.auth.register')
             ->set('name', 'Test User')
             ->set('email', 'test@example.com')
+            ->set('country', 'United States')
+            ->set('phone', '+1 555-123-4567')
+            ->set('company', 'Example Co.')
             ->set('password', 'password')
             ->set('password_confirmation', 'password');
 
@@ -32,5 +35,12 @@ class RegistrationTest extends TestCase
         $component->assertRedirect(route('dashboard', absolute: false));
 
         $this->assertAuthenticated();
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'test@example.com',
+            'country' => 'United States',
+            'phone' => '+1 555-123-4567',
+            'company' => 'Example Co.',
+        ]);
     }
 }

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -33,6 +33,9 @@ class ProfileTest extends TestCase
         $component = Volt::test('profile.update-profile-information-form')
             ->set('name', 'Test User')
             ->set('email', 'test@example.com')
+            ->set('country', 'United States')
+            ->set('phone', '+1 555-765-4321')
+            ->set('company', 'Example Co.')
             ->call('updateProfileInformation');
 
         $component
@@ -43,6 +46,9 @@ class ProfileTest extends TestCase
 
         $this->assertSame('Test User', $user->name);
         $this->assertSame('test@example.com', $user->email);
+        $this->assertSame('United States', $user->country);
+        $this->assertSame('+1 555-765-4321', $user->phone);
+        $this->assertSame('Example Co.', $user->company);
         $this->assertNull($user->email_verified_at);
     }
 


### PR DESCRIPTION
## Summary
- add country, phone, and company columns to the users table and model
- expose the new fields in the registration and profile forms with validation
- seed and factory updates so generated users include contact information
- extend auth tests to cover the new fields during registration and profile updates

## Testing
- not run (missing vendor directory)


------
https://chatgpt.com/codex/tasks/task_e_68dd0dce15b883269aeaab1cf93278c3