### PR TITLE
Add product-aware ticket creation flow

### DIFF
--- a/app/Http/Controllers/Customer/DashboardController.php
+++ b/app/Http/Controllers/Customer/DashboardController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Customer;
+
+use App\Http\Controllers\Controller;
+use App\Models\Product;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    /**
+     * Display the customer dashboard with products for ticket submission.
+     */
+    public function __invoke(Request $request): View
+    {
+        $products = Product::orderBy('name')->get();
+
+        return view('dashboards.customer', [
+            'products' => $products,
+        ]);
+    }
+}

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Ticket;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class TicketController extends Controller
+{
+    /**
+     * Store a newly created ticket in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'subject' => ['required', 'string', 'max:255'],
+            'details' => ['required', 'string'],
+            'product_id' => ['required', 'integer', 'exists:products,id'],
+            'type' => ['required', 'in:support,sale'],
+        ]);
+
+        Ticket::create([
+            'user_id' => $request->user()->id,
+            'product_id' => $validated['product_id'],
+            'title' => $validated['subject'],
+            'type' => $validated['type'],
+            'description' => $validated['details'],
+        ]);
+
+        return redirect()
+            ->route('customer.dashboard')
+            ->with('ticket_submitted', 'Your ticket has been submitted!');
+    }
+}

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Product extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'sku',
+        'description',
+    ];
+
+    /**
+     * A product can have many tickets associated with it.
+     */
+    public function tickets()
+    {
+        return $this->hasMany(Ticket::class);
+    }
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -11,9 +11,9 @@ class Ticket extends Model
 
     protected $fillable = [
         'user_id',
+        'product_id',
         'title',
         'type',
-        'project',
         'description',
         'status',
         'assigned_to',
@@ -35,5 +35,11 @@ class Ticket extends Model
     public function media()
     {
         return $this->hasMany(TicketMedia::class);
+    }
+
+    // 🔹 A ticket references a product
+    public function product()
+    {
+        return $this->belongsTo(Product::class);
     }
 }

--- a/database/migrations/2025_10_01_053300_create_products_table.php
+++ b/database/migrations/2025_10_01_053300_create_products_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('products', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('sku')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('products');
+    }
+};

--- a/database/migrations/2025_10_01_053351_create_tickets_table.php
+++ b/database/migrations/2025_10_01_053351_create_tickets_table.php
@@ -14,9 +14,9 @@ return new class extends Migration
         Schema::create('tickets', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->onDelete('cascade'); // Customer
+            $table->foreignId('product_id')->constrained()->onDelete('restrict');
             $table->string('title'); // Short subject/summary
-            $table->enum('type', ['sales', 'support']); // Enquiry type
-            $table->string('project')->nullable(); // Project/Product
+            $table->enum('type', ['sale', 'support']); // Enquiry type
             $table->text('description'); // Detailed explanation
             $table->enum('status', ['open', 'assigned', 'in_progress', 'resolved'])->default('open');
             $table->foreignId('assigned_to')->nullable()->constrained('users'); // Developer

--- a/resources/views/dashboards/customer.blade.php
+++ b/resources/views/dashboards/customer.blade.php
@@ -7,18 +7,26 @@
 
     <div class="py-12">
         <div class="max-w-5xl mx-auto sm:px-6 lg:px-8">
-            <div 
-                x-data="ticketFlow()" 
+            <div
+                x-data="ticketFlow(@js([
+                    'initialStep' => session()->has('ticket_submitted') ? 'success' : (old('type') ? 'form' : 'cards'),
+                    'initialType' => old('type'),
+                    'form' => [
+                        'subject' => old('subject', ''),
+                        'details' => old('details', ''),
+                        'productId' => old('product_id'),
+                    ],
+                ]))"
                 class="bg-white rounded-2xl shadow-xl p-10 relative overflow-hidden"
             >
                 <!-- Step 1: Card Selection -->
                 <template x-if="step === 'cards'">
-                    <div 
+                    <div
                         class="grid md:grid-cols-2 gap-8 relative z-10"
                         x-init="$el.classList.add('animate-fade-in')"
                     >
                         <!-- Sales Card -->
-                        <div @click="selectType('sales')" 
+                        <div @click="selectType('sale')"
                              class="cursor-pointer group p-8 rounded-2xl bg-white shadow-lg border border-gray-100 hover:scale-105 transition-transform duration-300 hover:shadow-xl opacity-0 animate-fade-in-up">
                             <div class="text-center">
                                 <div class="bg-indigo-100 text-indigo-600 w-16 h-16 flex items-center justify-center rounded-full mx-auto mb-4 group-hover:bg-indigo-200 transition-colors">
@@ -47,23 +55,55 @@
                 <template x-if="step === 'form'">
                     <div x-transition class="relative z-10">
                         <div class="flex justify-between items-center mb-6">
-                            <h3 class="text-xl font-semibold text-indigo-600" x-text="selectedType === 'sales' ? 'Sales Enquiry' : 'Customer Support'"></h3>
+                            <h3 class="text-xl font-semibold text-indigo-600" x-text="selectedType === 'sale' ? 'Sales Enquiry' : 'Customer Support'"></h3>
                             <button @click="cancelForm" class="text-sm text-gray-500 hover:text-red-500 transition">✖ Cancel</button>
                         </div>
-                        
-                        <form @submit.prevent="submitForm" class="space-y-5">
+
+                        <div class="space-y-5">
+                            @if ($errors->any())
+                                <div class="rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                                    <p class="font-semibold">We couldn't submit your ticket:</p>
+                                    <ul class="mt-2 list-disc space-y-1 pl-5">
+                                        @foreach ($errors->all() as $error)
+                                            <li>{{ $error }}</li>
+                                        @endforeach
+                                    </ul>
+                                </div>
+                            @endif
+                        </div>
+
+                        <form method="POST" action="{{ route('customer.tickets.store') }}" class="mt-6 space-y-5">
+                            @csrf
+                            <input type="hidden" name="type" :value="selectedType">
                             <div>
                                 <label class="block text-sm font-medium mb-1">Subject</label>
-                                <input type="text" x-model="form.subject" required
+                                <input type="text" name="subject" x-model="form.subject" required
                                     class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-indigo-400 focus:border-indigo-500 placeholder-gray-400 transition">
                             </div>
                             <div>
+                                <label class="block text-sm font-medium mb-1">Product</label>
+                                @if ($products->isEmpty())
+                                    <p class="rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm text-yellow-700">
+                                        No products are available yet. Please contact the administrator.
+                                    </p>
+                                @else
+                                    <select name="product_id" x-model="form.productId" required
+                                        class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-indigo-400 focus:border-indigo-500 transition">
+                                        <option value="" disabled x-bind:selected="!form.productId">Select a product</option>
+                                        @foreach ($products as $product)
+                                            <option value="{{ $product->id }}">{{ $product->name }}</option>
+                                        @endforeach
+                                    </select>
+                                @endif
+                            </div>
+                            <div>
                                 <label class="block text-sm font-medium mb-1">Details</label>
-                                <textarea rows="4" x-model="form.details" required
+                                <textarea rows="4" name="details" x-model="form.details" required
                                     class="w-full px-4 py-3 rounded-lg border border-gray-300 focus:ring-2 focus:ring-indigo-400 focus:border-indigo-500 placeholder-gray-400 transition"></textarea>
                             </div>
                             <button type="submit"
-                                class="w-full py-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white font-semibold shadow-md transition transform hover:scale-105">
+                                @if ($products->isEmpty()) disabled @endif
+                                class="w-full py-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-60 text-white font-semibold shadow-md transition transform hover:scale-105">
                                 📩 Submit Ticket
                             </button>
                         </form>
@@ -74,9 +114,9 @@
                 <template x-if="step === 'success'">
                     <div x-transition class="text-center relative z-10">
                         <div class="text-6xl mb-4">✅</div>
-                        <h3 class="text-2xl font-bold text-green-600">Your ticket has been submitted!</h3>
+                        <h3 class="text-2xl font-bold text-green-600">{{ session('ticket_submitted', 'Your ticket has been submitted!') }}</h3>
                         <p class="text-gray-600 mt-2">We’ll get back to you as soon as possible.</p>
-                        <button @click="resetFlow" 
+                        <button @click="resetFlow"
                             class="mt-6 px-6 py-3 rounded-lg bg-indigo-600 hover:bg-indigo-700 text-white font-semibold shadow-md transition">
                             Back to Dashboard
                         </button>
@@ -88,26 +128,28 @@
 </x-app-layout>
 
 <script>
-    function ticketFlow() {
+    function ticketFlow(config = {}) {
+        const form = config.form || {};
+
         return {
-            step: 'cards',
-            selectedType: null,
-            form: { subject: '', details: '' },
+            step: config.initialStep || 'cards',
+            selectedType: config.initialType || null,
+            form: {
+                subject: form.subject || '',
+                details: form.details || '',
+                productId: form.productId || '',
+            },
             selectType(type) {
                 this.selectedType = type;
                 this.step = 'form';
             },
             cancelForm() {
-                this.form = { subject: '', details: '' };
+                this.form = { subject: '', details: '', productId: '' };
                 this.step = 'cards';
-            },
-            submitForm() {
-                // You can hook Livewire or AJAX here
-                this.step = 'success';
+                this.selectedType = null;
             },
             resetFlow() {
-                this.form = { subject: '', details: '' };
-                this.step = 'cards';
+                window.location.href = '{{ route('customer.dashboard') }}';
             }
         }
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,12 +1,15 @@
 <?php
 
+use App\Http\Controllers\Customer\DashboardController as CustomerDashboardController;
+use App\Http\Controllers\TicketController;
 use Illuminate\Support\Facades\Route;
 
 Route::view('/', 'welcome');
 
 Route::middleware(['auth', 'verified', 'role:Customer'])
     ->group(function (): void {
-        Route::view('customer/dashboard', 'dashboards.customer')->name('customer.dashboard');
+        Route::get('customer/dashboard', CustomerDashboardController::class)->name('customer.dashboard');
+        Route::post('customer/tickets', [TicketController::class, 'store'])->name('customer.tickets.store');
     });
 
 Route::middleware(['auth', 'verified', 'role:Developer'])


### PR DESCRIPTION
## Summary
- add a products table and link tickets to products in the schema and model layer
- provide controllers and routes to load available products and persist submitted tickets with their type
- refresh the customer dashboard ticket form to surface a product dropdown and post to the backend

## Testing
- php artisan test *(fails: vendor autoloader is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e371be0ac48326b1bfcb675906d82d